### PR TITLE
Fix about page 500 error

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,10 +1,28 @@
 <?php
-$conn = @new mysqli("localhost", "jyotiffj_KiranJ", "K@9833514014j", "jyotiffj_jyoti_Enterprises");
-if ($conn->connect_error) {
+$db_error = null;
+$testimonials = [];
+
+if (!class_exists('mysqli')) {
   $db_error = 'Testimonials are temporarily unavailable. Please try again soon.';
-  $result = null;
 } else {
-  $result = $conn->query("SELECT name, message, rating FROM testimonials WHERE approved = 1 ORDER BY created_at DESC");
+  $conn = @new mysqli("localhost", "jyotiffj_KiranJ", "K@9833514014j", "jyotiffj_jyoti_Enterprises");
+  if ($conn->connect_error) {
+    $db_error = 'Testimonials are temporarily unavailable. Please try again soon.';
+  } else {
+    $result = $conn->query("SELECT name, message, rating FROM testimonials WHERE approved = 1 ORDER BY created_at DESC");
+    if ($result === false) {
+      $db_error = 'Testimonials are temporarily unavailable. Please try again soon.';
+    } else {
+      while ($row = $result->fetch_assoc()) {
+        $testimonials[] = $row;
+      }
+      $result->free();
+    }
+  }
+}
+
+if (isset($conn) && is_object($conn) && method_exists($conn, 'close')) {
+  $conn->close();
 }
 ?>
 <!DOCTYPE html>
@@ -424,14 +442,14 @@ if ($conn->connect_error) {
           <div class="client">Meenal K., Retail Experience Lead</div>
           <div class="rating">⭐⭐⭐⭐⭐</div>
         </article>
-        <?php if ($result && $result->num_rows > 0): ?>
-          <?php while ($row = $result->fetch_assoc()): ?>
+        <?php if (!empty($testimonials)): ?>
+          <?php foreach ($testimonials as $row): ?>
             <article class="testimonial-card">
               <p>“<?= htmlspecialchars($row['message']) ?>”</p>
               <div class="client">– <?= htmlspecialchars($row['name']) ?></div>
               <div class="rating"><?= str_repeat('⭐', (int) $row['rating']) ?></div>
             </article>
-          <?php endwhile; ?>
+          <?php endforeach; ?>
         <?php else: ?>
           <article class="testimonial-card">
             <p>“Be the first to drop a review from the future. We’re excited to hear about your install.”</p>


### PR DESCRIPTION
Refactor `about.php` to gracefully handle `mysqli` extension and database connection errors, preventing 500 errors and providing fallback content.

---
<a href="https://cursor.com/background-agent?bcId=bc-90f89b0e-cb65-4363-bfed-9355ec65cc46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90f89b0e-cb65-4363-bfed-9355ec65cc46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

